### PR TITLE
typos and broken links

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,12 +8,12 @@ docs:
         url: /overview/principles
       - title: Registers
         url: /overview/registers  
-      - title: Profiles
-        url: /overview/profiles 
       - title: Types (Technologies)
         url: /overview/types 
       - title: Types (Patterns)
         url: /overview/types#patterns
+      - title: Profiles
+        url: /overview/profiles 
       - title: Relationships
         url: /overview/relationships
   - title: Use Cases for Building Blocks

--- a/_pages/build/github.md
+++ b/_pages/build/github.md
@@ -3,11 +3,11 @@ title: Quick Start - Github Automation
 permalink: /build/github
 ---
 
-# Configuring Github automations for CI/CT build
+# Configuring Github automations for CI/CD build
 
 New and forked Github repositories need configuration to allow automated building. 
 
-1. Fork the template or another repository to a git organisation you have admin access for.
+1. Fork the template or another repositoryto a git organisation you have admin access for.
 1. In settings set "pages build" to "Github actions"
 ![](pages.png)
 2. Run the "validate and postprocess" action 

--- a/_pages/create/examples.md
+++ b/_pages/create/examples.md
@@ -9,7 +9,7 @@ Each example consists of Markdown `content` and/or a list of `snippets`. `snippe
 have a `language` (for highlighting, language tabs in Slate, etc.) and the `code` itself.
 
 `content` accepts text in Markdown format. Any relative links or images will be resolved to full
-URLs when the building block is published (see [Assets](#assets)).
+URLs when the building block is published.
 
 Instead of the `code`, a `ref` with a filename relative to `examples.yaml` can be provided:
 

--- a/_pages/create/postprocessing.md
+++ b/_pages/create/postprocessing.md
@@ -7,7 +7,7 @@ Building Blocks sources are post-processed using a workflow package maintained b
 
 
 
-![OGC Building Blocks processing](https://raw.githubusercontent.com/opengeospatial/bblocks-postprocess/master/process.png)
+[![OGC Building Blocks processing](https://raw.githubusercontent.com/opengeospatial/bblocks-postprocess/master/process.png)](https://raw.githubusercontent.com/opengeospatial/bblocks-postprocess/master/process.png)
 
 ### Output testing
 

--- a/_pages/create/structure.md
+++ b/_pages/create/structure.md
@@ -12,7 +12,7 @@ The following image summarizes the general usage of a building block:
 The `_sources` directory will contain the sources for the building blocks inside this repository.
 
 - `bblock.json`: Contains the metadata for the building block. Please refer to this
-  [JSON schema](https://raw.githubusercontent.com/opengeospatial/bblocks-postprocess/master/ogc/bblocks/schemas/metadata.schema.yaml)
+  [JSON schema](https://raw.githubusercontent.com/opengeospatial/bblocks-postprocess/refs/heads/master/ogc/bblocks/schemas/bblock.schema.yaml)
   for more information.
 - `description.md`: Human-readable, Markdown document with the description of this building block.
   See [Adding documentation](documentation) for more information.
@@ -20,7 +20,7 @@ The `_sources` directory will contain the sources for the building blocks inside
 - `schema.json`: JSON schema for this building block, if any. See [JSON schema](schema).
     - `schema.yaml`, in YAML format, is also accepted (and even preferred).
 - `assets/`: Documentation assets (e.g. images) directory. See [Assets](#assets) below.
-- `tests/`: Test resources. See [Validation](#validation-and-tests).
+- `tests/`: Test resources. See [Validation](validation).
 
 Building Block identifiers are automatically generated in the form:
 
@@ -31,7 +31,7 @@ Building Block identifiers are automatically generated in the form:
 where:
 
 - `identifier-prefix` is read from `bblocks-config.yaml`. This will initially be a placeholder value,
-  but should have an official value eventually (see [How-to](#how-to)).
+  but should have an official value eventually (see [How-to](/create/#quick-how-to-create)).
 - `bb-path` is the dot-separated path to the building block inside the repository.
 
 For example, given a `r1.branch1.` identifier prefix and a `cat1/cat2/my-bb/bblock.json` metadata file,

--- a/_pages/overview/principles.md
+++ b/_pages/overview/principles.md
@@ -31,7 +31,7 @@ Many specification languages or target technologies are poor at exposing such de
 
 Building Blocks must support re-use of components across different governance domains. This is supported by [Transparency](#transparency-of-dependencies-and-commonality).
 
-Managing distributed development and evolution cycles is supported by [Regression Testing](#testing.)
+Managing distributed development and evolution cycles is supported by [Regression Testing](#testing).
 
 ## Profiling
 
@@ -43,10 +43,10 @@ See [Profiles](profiles.md)
 
 Testing is automated, and functions in at least four modes:
 
-1) Basic syntax checking of components and descriptions
-2) Unit tests of example implementations for individual components, including positive and negative tests
-3) Integration testing, including inheritance of tests from dependencies
-4) Regression testing to ensure continual compliance with dependent components.
+1. Basic syntax checking of components and descriptions
+2. Unit tests of example implementations for individual components, including positive and negative tests
+3. Integration testing, including inheritance of tests from dependencies
+4. Regression testing to ensure continual compliance with dependent components.
 
 
 

--- a/_pages/overview/profiles.md
+++ b/_pages/overview/profiles.md
@@ -3,11 +3,10 @@ title: Profiles
 permalink: /overview/profiles
 ---
 
-BuildingBlocks support two usage modes:
-- composition
-- profiling
+BuildingBlocks support several usage modes, as described in [Types (Patterns)](types#patterns)
 
-This document described profiling mechanisms.
+
+This section describes the profiling mechanisms in more detail.
 
 **Profiles** allow all the underlying details of base standards to be automatically included in testing and validation - this _encapsulates_ the underlying complexity of base specifications.
  
@@ -25,7 +24,7 @@ Because many technologies like JSON and RDF are permissive (by default) about ad
 
 ## Profiles of profiles... 
 
-Profiles can be designed as separate re-usable sets of constraints that can be reused - for example a time-series of water-quality monitoring observations could be specified as a profile of both a time-series profile of Observations and a water-quality profile for the results of such observations.
+Profiles can be designed as separate re-usable sets of [**constraints**](profiles#what-forms-of-constraints-are-possible) that can be reused - for example a time-series of water-quality monitoring observations could be specified as a profile of both a time-series profile of Observations and a water-quality profile for the results of such observations.
 In turn the time-series profile could defined as data structure using GeoJSON, or Coverage JSON.  The water-quality content requirements could be described using constraints independent of the data structure.
 
 ## Profiles for infrastructure compatibility
@@ -36,7 +35,7 @@ Underlying standards allow reusable software and libraries to be used at all lev
 
 This can be visualised as a layered model of typical profiles, identifying the types of constraints typically present at each layer. 
 
-![Profile layers](profiles.png)
+[![Profile layers](profiles.png)](profiles.png)
 
 
 ## What forms of constraints are possible?
@@ -53,7 +52,7 @@ Built-in support is provided for automatic validation of the following forms:
 
 In addition [custom validators](../create/validation) can be added to the validation workflow. 
 
-Using a JSON-LD context "semantic uplift" of JSON to RDF supports use of SHACL and other forms of validators to 
+Using a JSON-LD context "semantic uplift" of JSON to RDF supports use of SHACL and other forms of validators for validation.
 
 ## Testing
 

--- a/_pages/overview/registers.md
+++ b/_pages/overview/registers.md
@@ -14,4 +14,4 @@ Key examples include:
 - [Examples](https://ogcincubator.github.io/bblocks-examples/) - Examples of different types and usage patterns. (_these are NOT intended as reuse except in examples and tutorials_)
 - [Tutorial](https://ogcincubator.github.io/bblocks-tutorial/) - a step-wise introduction to various features and configuration details for Building Blocks.
 
-![OGC Building Block Register Ecosystem](https://lucid.app/publicSegments/view/9d075f82-8611-4f32-83eb-994143669cc8/image.png)
+[![OGC Building Block Register Ecosystem](https://lucid.app/publicSegments/view/9d075f82-8611-4f32-83eb-994143669cc8/image.png)](https://lucid.app/publicSegments/view/9d075f82-8611-4f32-83eb-994143669cc8/image.png)

--- a/_pages/overview/relantionships.md
+++ b/_pages/overview/relantionships.md
@@ -12,7 +12,7 @@ This relationship implies that a building block depends on another, in a generic
 This is the default type of relationship that exists, for example, when the schema of a building
 block is referenced from another. 
 
-This type of dependency uses the `dependsOn` property in the building blocks register and metadata files.
+This type of dependency is declared using `dependsOn` in `bblock.json`.
 
 ## <a name="type-profileOf"></a>Profiling (`profileOf`)
 
@@ -27,7 +27,7 @@ When defining [extension points](../create/extension-points.md), three new types
 
 ### <a name="type-extends"></a>Extends
 
-This relationship links a building block with the another that is used as an extension base, and for 
+This relationship links a building block with another that is used as an extension base, and for 
 which extension points are defined. It is a special case of the `profileOf` property.
 
 ### <a name="type-extensionTarget"></a>Extension target

--- a/_pages/overview/types.md
+++ b/_pages/overview/types.md
@@ -16,7 +16,7 @@ Key types include:
 - transformations from XML, CSV, etc to validatable forms (JSON, RDF)
 - rules (constraints on other schemas or RDF models)
 
-In all cases, the Building Block annotations provide transparent dependency declarations and the opportunity to systematically test example.
+In all cases, the Building Block annotations provide transparent dependency declarations and the opportunity to systematically test examples.
 
 # Patterns
 

--- a/_pages/overview/whatis.md
+++ b/_pages/overview/whatis.md
@@ -4,15 +4,15 @@ permalink: /overview/whatis
 ---
 An Building Block is a way of packaging a component of a **specification** that can be re-used in other specifications.
 
-This packaging directly supports **reuse** (according to FAIR principles), following these [Design Principles](overview/principles).
+This packaging directly supports **reuse** (according to FAIR principles), following these [Design Principles](principles).
 
-For various reasons specifications have often made statements in text regarding how they relate to other specifications, and created implementation artefacts such as schemas that may not make these intentions explicit. OGC Building Blocks support **technology agnostic dependency and rtelationshops** - essentially forming the data management method for this apsect of OGC's knowledge graph (OGC RAINBOW).
+For various reasons specifications have often made statements in text regarding how they relate to other specifications, and created implementation artefacts such as schemas that may not make these intentions explicit. OGC Building Blocks support **technology agnostic dependencies and relationships** - essentially forming the data management method for this apsect of OGC's knowledge graph (OGC RAINBOW).
 
-The key focus is on automated quality control, via inheritable testing on a simple aspect-by-aspect basis for standards as they are composed from common specification elements into comprehensive specifications to support data exchange and analysis applications/  
+The key focus is on automated quality control, via inheritable testing on a simple aspect-by-aspect basis for standards as they are composed from common specification elements into comprehensive specifications to support data exchange and analysis applications.  
 
 The following diagram shows how Building Blocks form a value-added packaging option for such specification elements that can then be exploited as part of a comprehensive knowledge base to support discovery and re-use (FAIR principles).
 
-![Overview](https://lucid.app/publicSegments/view/266abfd3-ed51-43a8-a9b0-8e3251c28b54/image.png)
+[![Overview](https://lucid.app/publicSegments/view/266abfd3-ed51-43a8-a9b0-8e3251c28b54/image.png)](https://lucid.app/publicSegments/view/266abfd3-ed51-43a8-a9b0-8e3251c28b54/image.png)
 
 Many OGC Standards contain reusable building blocks that can be used in other OGC Standards. The Standards themselves can also be structured with modular sets of requirements that collectively function as a reusable building block (see image bellow).
 

--- a/_pages/use/linked-data.md
+++ b/_pages/use/linked-data.md
@@ -23,5 +23,4 @@ The challenges with JSON-LD lie in its mirroring of underlying JSON schema struc
 The OGC Building Blocks **solve this** by allowing unit-testing of simple JSON-LD contexts for sub-schemas, and compilation of reliable context documents for schemas that re-use these sub-schemas.
 (Note this is currently the only Open Source tooling known to support this, and was developed in consultation with JSON schema design leads.)
 
-For more information refer the [Use Cases](/usecases/usecases) and 
-
+For more information see the [Use Cases](/usecases/usecases).

--- a/_pages/usecases/stac_extension.md
+++ b/_pages/usecases/stac_extension.md
@@ -12,7 +12,7 @@ _(This is a work in progress and we will explore even better ways to support STA
 
 STAC extensions are defined in a repository and provide a number of elements - they are in fact a "STAC Building Block" in that they can be combined with each other. ("Building" is the fundamental concept here!)
 
-The current approach to defining a STAC extension](https://stac-extensions.github.io/) currently is based on a git repository template, then editing a full copy of the STAC item and/or collection schemas.
+The current approach to defining a [STAC extension](https://stac-extensions.github.io/) currently is based on a git repository template, then editing a full copy of the STAC item and/or collection schemas.
 
 This approach has several issues that could be improved:
 
@@ -29,7 +29,7 @@ This approach has several issues that could be improved:
 
 ### Building Blocks for STAC
 
-most of the limitations discussed above could be avoided by using a formal register of Building Blocks with a simplified profiling mechanism - with auto-generation of STAC schemas for a suite of supported versions.
+Most of the limitations discussed above could be avoided by using a formal register of Building Blocks with a simplified profiling mechanism - with auto-generation of STAC schemas for a suite of supported versions.
 
 Using the OGC Building Blocks approach to define or annotate a STAC extension provides an additional layer of support for:
 

--- a/_pages/usecases/usecases.md
+++ b/_pages/usecases/usecases.md
@@ -5,7 +5,7 @@ permalink: /usecases/usecases
 
 ## Writing a new standard
 
-SWGs and document Editors need a simple capability to search and determine if there is a _requirements class_ somewhere in some OGC Standard that they can reuse. Then, if they find that requirements class,  the can use a reference (and unique identifier).   Then at publication, the full content (including the conformance test classes and OpenAPI/YAML content for API standards) would be shown but not actually duplicated. This is the standards' developer use case.
+SWGs and document Editors need a simple capability to search and determine if there is a _requirements class_ somewhere in some OGC Standard that they can re-use. Then, if they find that requirements class,  they can use a reference (and unique identifier).   Then at publication, the full content (including the conformance test classes and OpenAPI/YAML content for API standards) would be shown but not actually duplicated. This is the standards' developer use case.
 
 Note that this is not something that is consistently done, or easy to do in the normal course of standards development:
 
@@ -76,7 +76,7 @@ Reduces cost, time, risk and documentation burden on application design.
 
 ### Interoperability of the application with other related applications
 
-Reuse of components accelerates design and reduces documentation and testing burdens.  A common documentation style reduces cost of interoperability when integrating different systems. Transparency of reuse of common components reduces the cost of identifying interoperability opportunities and where custom solutions will be required.  For a typical application it is expected that most components will not be unique, and use of well described profiles can address application specific requirements rather than design and documentation of all aspects of component behaviour.
+Re-use of components accelerates design and reduces documentation and testing burdens.  A common documentation style reduces cost of interoperability when integrating different systems. Transparency of re-use of common components reduces the cost of identifying interoperability opportunities and where custom solutions will be required.  For a typical application it is expected that most components will not be unique, and use of well described profiles can address application specific requirements rather than design and documentation of all aspects of component behaviour.
 
 ### Deployability of an application in an infrastructure context
 


### PR DESCRIPTION
I went through the documentation today and spotted some typos and broken links...

- switching the profiles page to after the types (patterns) makes more sense I think because then the profile/composition paradigm is introduced.
